### PR TITLE
Group products by year on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { products } from "@/lib/products";
+import { Fragment } from "react";
 export default function Home() {
   return (
     <main className="min-h-screen bg-background font-body text-foreground">
@@ -7,26 +8,35 @@ export default function Home() {
           Products by Apple
         </h1>
         <div className="border-t border-border">
-          {products.map((product, index) => (
-            <div
-              key={index}
-              className="group transition-colors duration-200 ease-in-out hover:bg-accent border-b border-border cursor-pointer"
-            >
-              <div className="p-6">
-                <div className="grid grid-cols-1 md:grid-cols-12 gap-x-8 gap-y-2 items-center">
-                  <div className="md:col-span-2">
-                    <p className="text-sm text-muted-foreground">{product.year}</p>
+          {products.map((product, index) => {
+            const showYearHeader = index === 0 || product.year !== products[index - 1].year;
+            return (
+              <Fragment key={index}>
+                {showYearHeader && (
+                  <div className="border-b border-border bg-background p-4">
+                    <h2 className="text-xl font-semibold text-foreground">{product.year}</h2>
                   </div>
-                  <div className="md:col-span-4">
-                    <h2 className="font-semibold text-foreground">{product.title}</h2>
-                  </div>
-                  <div className="md:col-span-6">
-                    <p className="text-sm text-muted-foreground">{product.description}</p>
+                )}
+                <div
+                  className="group transition-colors duration-200 ease-in-out hover:bg-accent border-b border-border cursor-pointer"
+                >
+                  <div className="p-6">
+                    <div className="grid grid-cols-1 md:grid-cols-12 gap-x-8 gap-y-2 items-center">
+                      <div className="md:col-span-2">
+                        <p className="text-sm text-muted-foreground">{product.year}</p>
+                      </div>
+                      <div className="md:col-span-4">
+                        <h2 className="font-semibold text-foreground">{product.title}</h2>
+                      </div>
+                      <div className="md:col-span-6">
+                        <p className="text-sm text-muted-foreground">{product.description}</p>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          ))}
+              </Fragment>
+            );
+          })}
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- group product listings by year on home page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_686846d00874832eaef8a2c691ce7ed9