### PR TITLE
Add optional product images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,10 @@
 import { products } from "@/lib/products";
 import Image from "next/image";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 export default function Home() {
+  const [openImage, setOpenImage] = useState<{src: string; alt: string} | null>(
+    null
+  );
   return (
     <main className="min-h-screen bg-background font-body text-foreground">
       <div className="container mx-auto max-w-4xl py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
@@ -19,6 +22,10 @@ export default function Home() {
                   </div>
                 )}
                 <div
+                  onClick={() =>
+                    product.image &&
+                    setOpenImage({ src: product.image!, alt: product.title })
+                  }
                   className="group transition-colors duration-200 ease-in-out hover:bg-accent border-b border-border cursor-pointer"
                 >
                   <div className="p-6">
@@ -49,6 +56,22 @@ export default function Home() {
           })}
         </div>
       </div>
+      {openImage && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          onClick={() => setOpenImage(null)}
+        >
+          <div className="relative w-full h-full">
+            <Image
+              src={openImage.src}
+              alt={openImage.alt}
+              fill
+              unoptimized
+              className="object-contain animate-in zoom-in-95 fade-in"
+            />
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { products } from "@/lib/products";
 import Image from "next/image";
 import { Fragment, useState } from "react";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ export default function Home() {
                             alt={product.title}
                             width={96}
                             height={64}
+                            unoptimized
                             className="object-contain"
                           />
                         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { products } from "@/lib/products";
+import Image from "next/image";
 import { Fragment } from "react";
 export default function Home() {
   return (
@@ -22,6 +23,13 @@ export default function Home() {
                 >
                   <div className="p-6">
                     <div className="grid grid-cols-1 md:grid-cols-12 gap-x-8 gap-y-2 items-center">
+                      <div className="md:col-span-2 hidden md:block">
+                        {product.image && (
+                          <div className="relative h-16 w-24">
+                            <Image src={product.image} alt={product.title} fill className="object-contain" />
+                          </div>
+                        )}
+                      </div>
                       <div className="md:col-span-4">
                         <h2 className="font-semibold text-foreground">{product.title}</h2>
                       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,9 +25,13 @@ export default function Home() {
                     <div className="grid grid-cols-1 md:grid-cols-12 gap-x-8 gap-y-2 items-center">
                       <div className="md:col-span-2 hidden md:block">
                         {product.image && (
-                          <div className="relative h-16 w-24">
-                            <Image src={product.image} alt={product.title} fill className="object-contain" />
-                          </div>
+                          <Image
+                            src={product.image}
+                            alt={product.title}
+                            width={96}
+                            height={64}
+                            className="object-contain"
+                          />
                         )}
                       </div>
                       <div className="md:col-span-4">

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -2,12 +2,14 @@ export const products = [
   {
     "year": "1976",
     "title": "Apple I",
-    "description": "The first computer made by Apple, hand-built by Steve Wozniak."
+    "description": "The first computer made by Apple, hand-built by Steve Wozniak.",
+    "image": "https://placehold.co/200x120?text=Apple+I"
   },
   {
     "year": "1977",
     "title": "Apple II",
-    "description": "Apple's first mass-market personal computer, known for its color graphics and open architecture."
+    "description": "Apple's first mass-market personal computer, known for its color graphics and open architecture.",
+    "image": "https://placehold.co/200x120?text=Apple+II"
   },
   {
     "year": "1978",
@@ -122,7 +124,8 @@ export const products = [
   {
     "year": "1984",
     "title": "Macintosh 128K",
-    "description": "The original Macintosh, the first successful mass-market personal computer with a GUI."
+    "description": "The original Macintosh, the first successful mass-market personal computer with a GUI.",
+    "image": "https://placehold.co/200x120?text=Macintosh+128K"
   },
   {
     "year": "1984",
@@ -1202,7 +1205,8 @@ export const products = [
   {
     "year": "1998",
     "title": "iMac G3",
-    "description": "A colorful, all-in-one computer that revitalized Apple's fortunes."
+    "description": "A colorful, all-in-one computer that revitalized Apple's fortunes.",
+    "image": "https://placehold.co/200x120?text=iMac+G3"
   },
   {
     "year": "1999",
@@ -1592,7 +1596,8 @@ export const products = [
   {
     "year": "2007",
     "title": "iPhone (1st generation) (8 GB)",
-    "description": "A higher-capacity version of the original iPhone."
+    "description": "A higher-capacity version of the original iPhone.",
+    "image": "https://placehold.co/200x120?text=Original+iPhone"
   },
   {
     "year": "2007",
@@ -1892,7 +1897,8 @@ export const products = [
   {
     "year": "2010",
     "title": "iPad (Wi-Fi)",
-    "description": "Apple's first tablet computer, creating a new product category."
+    "description": "Apple's first tablet computer, creating a new product category.",
+    "image": "https://placehold.co/200x120?text=iPad+1"
   },
   {
     "year": "2010",
@@ -2357,7 +2363,8 @@ export const products = [
   {
     "year": "2015",
     "title": "Apple Watch (1st generation)",
-    "description": "Apple's first smartwatch, integrating fitness tracking and notifications."
+    "description": "Apple's first smartwatch, integrating fitness tracking and notifications.",
+    "image": "https://placehold.co/200x120?text=Apple+Watch"
   },
   {
     "year": "2015",

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -3,13 +3,13 @@ export const products = [
     "year": "1976",
     "title": "Apple I",
     "description": "The first computer made by Apple, hand-built by Steve Wozniak.",
-    "image": "https://placehold.co/200x120?text=Apple+I"
+    "image": "https://upload.wikimedia.org/wikipedia/commons/e/e4/CopsonApple1_2k_cropped.jpg"
   },
   {
     "year": "1977",
     "title": "Apple II",
     "description": "Apple's first mass-market personal computer, known for its color graphics and open architecture.",
-    "image": "https://placehold.co/200x120?text=Apple+II"
+    "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Apple_II-IMG_7064.jpg/1200px-Apple_II-IMG_7064.jpg"
   },
   {
     "year": "1978",
@@ -49,7 +49,8 @@ export const products = [
   {
     "year": "1980",
     "title": "Apple III",
-    "description": "A business-oriented personal computer, intended as the successor to the Apple II."
+    "description": "A business-oriented personal computer, intended as the successor to the Apple II.",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple3.jpg"
   },
   {
     "year": "1980",
@@ -1125,7 +1126,8 @@ export const products = [
   {
     "year": "1997",
     "title": "Twentieth Anniversary Macintosh",
-    "description": "A limited-edition, luxury Macintosh desktop."
+    "description": "A limited-edition, luxury Macintosh desktop.",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/f/f6/Apple_Museum_%28Prague%29_20th_Anniversary_Mac_%281997%29.jpg"
   },
   {
     "year": "1997",


### PR DESCRIPTION
## Summary
- support product images in the home page list
- extend sample product data with image URLs for major products

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68684d9ad0fc832e919ba91a0b9144b0