### PR TITLE
Add eBay listings integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+EBAY_APP_ID=your-ebay-app-id

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
-firebase-debug.log
-firestore-debug.log
+firebase-debug.logfirestore-debug.log

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## eBay Listings
+
+The app can fetch live eBay listings for each product. Set an environment
+variable `EBAY_APP_ID` with your eBay developer application ID to enable this
+feature.

--- a/src/app/api/ebay/route.ts
+++ b/src/app/api/ebay/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get("q");
+  if (!query) {
+    return NextResponse.json({ error: "Missing query" }, { status: 400 });
+  }
+
+  const appId = process.env.EBAY_APP_ID;
+  if (!appId) {
+    return NextResponse.json({ error: "Missing eBay credentials" }, { status: 500 });
+  }
+
+  const url =
+    "https://svcs.ebay.com/services/search/FindingService/v1" +
+    `?OPERATION-NAME=findItemsByKeywords` +
+    `&SERVICE-VERSION=1.13.0` +
+    `&SECURITY-APPNAME=${appId}` +
+    `&RESPONSE-DATA-FORMAT=JSON` +
+    `&keywords=${encodeURIComponent(query)}` +
+    `&paginationInput.entriesPerPage=3`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      return NextResponse.json({ error: "Failed to fetch" }, { status: 500 });
+    }
+    const data = await res.json();
+    const items =
+      data.findItemsByKeywordsResponse?.[0]?.searchResult?.[0]?.item || [];
+    const links = items
+      .map((item: any) => item.viewItemURL?.[0])
+      .filter(Boolean);
+    return NextResponse.json({ links });
+  } catch (err) {
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@
 import { products } from "@/lib/products";
 import Image from "next/image";
 import { Fragment, useState } from "react";
+import { useEbayListings } from "@/hooks/use-ebay-listings";
 
 interface Product {
   year: string;
@@ -20,6 +21,7 @@ interface Product {
 }
 export default function Home() {
   const [openProduct, setOpenProduct] = useState<Product | null>(null);
+  const ebayLinks = useEbayListings(openProduct ? openProduct.title : null);
   return (
     <main className="min-h-screen bg-background font-body text-foreground">
       <div className="container mx-auto max-w-4xl py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
@@ -91,6 +93,22 @@ export default function Home() {
                 <h3 className="text-lg font-semibold">{openProduct.year}</h3>
                 <h2 className="text-2xl font-bold">{openProduct.title}</h2>
                 <p className="text-sm">{openProduct.description}</p>
+                {ebayLinks.length > 0 && (
+                  <ul className="space-y-1 pt-2">
+                    {ebayLinks.map((link, idx) => (
+                      <li key={idx}>
+                        <a
+                          href={link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline text-blue-400"
+                        >
+                          eBay Link
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
             </div>
           </div>

--- a/src/hooks/use-ebay-listings.ts
+++ b/src/hooks/use-ebay-listings.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from "react";
+
+export function useEbayListings(query: string | null) {
+  const [links, setLinks] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!query) return;
+    let cancelled = false;
+    const fetchListings = async () => {
+      try {
+        const res = await fetch(`/api/ebay?q=${encodeURIComponent(query)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) {
+          setLinks(Array.isArray(data.links) ? data.links : []);
+        }
+      } catch (err) {
+        console.error("Failed to fetch eBay listings", err);
+      }
+    };
+    fetchListings();
+    return () => {
+      cancelled = true;
+    };
+  }, [query]);
+
+  return links;
+}


### PR DESCRIPTION
## Summary
- add `.env.example` and allow it in gitignore
- document `EBAY_APP_ID` requirement
- create API route calling the eBay Finding API
- implement `useEbayListings` hook to fetch results
- render eBay links when viewing a product

## Testing
- `npm run typecheck` *(fails: Cannot find module...)*

------
https://chatgpt.com/codex/tasks/task_e_686e6ede4b80832e9b686436225f125f