### PR TITLE
Add Etsy listing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ create a `.env` file with your Etsy API key:
 ```bash
 ETSY_API_KEY=your-api-key
 ```
+
+To try the Etsy feature without an API key, you can enable mock mode by setting
+the following flag in your `.env` file:
+
+```bash
+USE_MOCK_ETSY=true
+```

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Etsy API
+
+Some features search Etsy for product listings. To enable this functionality,
+create a `.env` file with your Etsy API key:
+
+```bash
+ETSY_API_KEY=your-api-key
+```

--- a/src/app/api/etsy-search/route.ts
+++ b/src/app/api/etsy-search/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get('q');
+  if (!query) {
+    return NextResponse.json({ error: 'Missing query' }, { status: 400 });
+  }
+
+  const apiKey = process.env.ETSY_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'ETSY_API_KEY not configured' }, { status: 500 });
+  }
+
+  const endpoint = `https://openapi.etsy.com/v3/application/listings/active?keywords=${encodeURIComponent(query)}&limit=5&sort_on=score`;
+
+  const res = await fetch(endpoint, {
+    headers: {
+      'x-api-key': apiKey,
+    },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Etsy API error', text);
+    return NextResponse.json({ error: 'Failed to fetch from Etsy' }, { status: 500 });
+  }
+
+  const data = await res.json();
+  const items = Array.isArray(data.results) ? data.results : [];
+  const links = items.map((item: any) => item.url).filter(Boolean);
+  const unique = Array.from(new Set(links)).slice(0, 5);
+
+  return NextResponse.json({ links: unique });
+}

--- a/src/app/api/etsy-search/route.ts
+++ b/src/app/api/etsy-search/route.ts
@@ -7,6 +7,14 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Missing query' }, { status: 400 });
   }
 
+  const useMock = process.env.USE_MOCK_ETSY === 'true';
+
+  if (useMock) {
+    const base = `https://www.etsy.com/search?q=${encodeURIComponent(query)}`;
+    const links = Array.from({ length: 5 }, (_, i) => `${base}&mock=${i + 1}`);
+    return NextResponse.json({ links });
+  }
+
   const apiKey = process.env.ETSY_API_KEY;
   if (!apiKey) {
     return NextResponse.json({ error: 'ETSY_API_KEY not configured' }, { status: 500 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@
 import { products } from "@/lib/products";
 import Image from "next/image";
 import { Fragment, useState } from "react";
+import EtsyLinks from "@/components/etsy/EtsyLinks";
 
 interface Product {
   year: string;
@@ -59,6 +60,7 @@ export default function Home() {
                       </div>
                       <div className="md:col-span-6">
                         <p className="text-sm text-muted-foreground">{product.description}</p>
+                        <EtsyLinks query={`${product.title} ${product.description}`} />
                       </div>
                     </div>
                   </div>
@@ -91,6 +93,7 @@ export default function Home() {
                 <h3 className="text-lg font-semibold">{openProduct.year}</h3>
                 <h2 className="text-2xl font-bold">{openProduct.title}</h2>
                 <p className="text-sm">{openProduct.description}</p>
+                <EtsyLinks query={`${openProduct.title} ${openProduct.description}`} />
               </div>
             </div>
           </div>

--- a/src/components/etsy/EtsyLinks.tsx
+++ b/src/components/etsy/EtsyLinks.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Props {
+  query: string
+}
+
+export default function EtsyLinks({ query }: Props) {
+  const [links, setLinks] = useState<string[]>([])
+
+  useEffect(() => {
+    async function fetchLinks() {
+      try {
+        const res = await fetch(`/api/etsy-search?q=${encodeURIComponent(query)}`)
+        if (!res.ok) return
+        const data = await res.json()
+        if (Array.isArray(data.links)) {
+          setLinks(data.links)
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchLinks()
+  }, [query])
+
+  if (links.length === 0) return null
+
+  return (
+    <div className="mt-1 space-y-1">
+      {links.map((link, idx) => (
+        <div key={idx}>
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-600 underline"
+          >
+            Etsy Link
+          </a>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- use Etsy API to fetch links for items
- display Etsy links for items in the product list and overlay
- add API route for Etsy search
- document Etsy API setup

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for packages)*

------
https://chatgpt.com/codex/tasks/task_e_6872cf935c0c832e8194d3701db03186