### PR TITLE
docs: clarify eBay env variable setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,17 @@ To get started, take a look at src/app/page.tsx.
 ## eBay Listings
 
 The app can fetch live eBay listings for each product using the eBay sandbox.
-Set an environment variable `EBAY_SANDBOX_APP_ID` with your sandbox
-application ID to enable this feature.
+To enable this feature you need to provide your sandbox application ID.
+
+1. Copy the provided example file and edit the value:
+
+   ```bash
+   cp .env.example .env.local
+   # open .env.local and replace the placeholder
+   ```
+
+2. Alternatively, export the variable in your shell before starting the
+   development server.
+
+With `EBAY_SANDBOX_APP_ID` defined in `.env.local` (or your environment)
+`process.env.EBAY_SANDBOX_APP_ID` will resolve correctly.


### PR DESCRIPTION
## Summary
- clarify how to configure the EBAY_SANDBOX_APP_ID variable

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68752e4fb35c832ea0c88749a5297dbc