### PR TITLE
Switch eBay listings to Browse API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
-EBAY_SANDBOX_APP_ID=your-sandbox-app-id
+# eBay API configuration
+# Set EBAY_ENV to 'sandbox' for testing or 'production' for the live API
+EBAY_ENV=sandbox
+
+# OAuth token obtained via the sandbox using client credentials
+EBAY_SANDBOX_OAUTH_TOKEN=your-sandbox-oauth-token
+
+# OAuth token for the production environment (required when EBAY_ENV=production)
+EBAY_OAUTH_TOKEN=your-production-oauth-token

--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ To get started, take a look at src/app/page.tsx.
 
 ## eBay Listings
 
-The app can fetch live eBay listings for each product using the eBay sandbox.
-To enable this feature you need to provide your sandbox application ID.
+The app fetches live eBay listings using the Browse API. You can target the
+sandbox or production environment.
 
-1. Copy the provided example file and edit the value:
+1. Copy the provided example file and edit the values:
 
    ```bash
    cp .env.example .env.local
-   # open .env.local and replace the placeholder
+   # open .env.local and replace the placeholders
    ```
 
-2. Alternatively, export the variable in your shell before starting the
-   development server.
+2. Set `EBAY_ENV` to either `sandbox` or `production`.
+   - When using the sandbox, provide `EBAY_SANDBOX_OAUTH_TOKEN`.
+   - When using production, provide `EBAY_OAUTH_TOKEN`.
 
-With `EBAY_SANDBOX_APP_ID` defined in `.env.local` (or your environment)
-`process.env.EBAY_SANDBOX_APP_ID` will resolve correctly.
+Alternatively, export the variables in your shell before starting the
+development server.

--- a/src/app/api/ebay/route.ts
+++ b/src/app/api/ebay/route.ts
@@ -1,6 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 
-console.log("EBAY_SANDBOX_APP_ID", process.env.EBAY_SANDBOX_APP_ID);
+const ENDPOINTS = {
+  sandbox: "https://api.sandbox.ebay.com/buy/browse/v1/item_summary/search",
+  production: "https://api.ebay.com/buy/browse/v1/item_summary/search",
+} as const;
+
+function getConfig(env?: string) {
+  const mode = env === "production" ? "production" : "sandbox";
+  const token =
+    mode === "production"
+      ? process.env.EBAY_OAUTH_TOKEN
+      : process.env.EBAY_SANDBOX_OAUTH_TOKEN;
+  return { mode, token, endpoint: ENDPOINTS[mode] };
+}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -9,31 +21,32 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Missing query" }, { status: 400 });
   }
 
-  const appId = process.env.EBAY_SANDBOX_APP_ID;
-  if (!appId) {
-    return NextResponse.json({ error: "Missing eBay credentials" }, { status: 500 });
+  const envOverride = searchParams.get("env") || undefined;
+  const { token, endpoint } = getConfig(envOverride || process.env.EBAY_ENV);
+
+  if (!token) {
+    return NextResponse.json(
+      { error: "Missing eBay credentials" },
+      { status: 500 }
+    );
   }
 
   const url =
-    "https://svcs.sandbox.ebay.com/services/search/FindingService/v1" +
-    `?OPERATION-NAME=findItemsByKeywords` +
-    `&SERVICE-VERSION=1.13.0` +
-    `&SECURITY-APPNAME=${appId}` +
-    `&RESPONSE-DATA-FORMAT=JSON` +
-    `&keywords=${encodeURIComponent(query)}` +
-    `&paginationInput.entriesPerPage=3`;
+    `${endpoint}?q=${encodeURIComponent(query)}&limit=3`;
 
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
     if (!res.ok) {
       return NextResponse.json({ error: "Failed to fetch" }, { status: 500 });
     }
     const data = await res.json();
-    const items =
-      data.findItemsByKeywordsResponse?.[0]?.searchResult?.[0]?.item || [];
-    const links = items
-      .map((item: any) => item.viewItemURL?.[0])
-      .filter(Boolean);
+    const items = data.itemSummaries || [];
+    const links = items.map((item: any) => item.itemWebUrl).filter(Boolean);
     return NextResponse.json({ links });
   } catch (err) {
     return NextResponse.json({ error: "Failed" }, { status: 500 });


### PR DESCRIPTION
## Summary
- update eBay API route to call the Browse API
- add environment toggle to choose sandbox or production
- document OAuth requirements for both environments
- update `.env.example` with sandbox and production tokens

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing type declarations)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68756717d56c832e991a29aa74e3d0dc