### PR TITLE
Improve eBay link display

### DIFF
--- a/src/app/api/ebay/route.ts
+++ b/src/app/api/ebay/route.ts
@@ -50,6 +50,10 @@ export async function GET(request: NextRequest) {
       .map((item: any) => ({
         url: item.itemWebUrl,
         title: item.title,
+        image:
+          item.image?.imageUrl ||
+          item.thumbnailImages?.[0]?.imageUrl ||
+          null,
       }))
       .filter((i) => i.url && i.title);
     return NextResponse.json({ listings });

--- a/src/app/api/ebay/route.ts
+++ b/src/app/api/ebay/route.ts
@@ -46,8 +46,13 @@ export async function GET(request: NextRequest) {
     }
     const data = await res.json();
     const items = data.itemSummaries || [];
-    const links = items.map((item: any) => item.itemWebUrl).filter(Boolean);
-    return NextResponse.json({ links });
+    const listings = items
+      .map((item: any) => ({
+        url: item.itemWebUrl,
+        title: item.title,
+      }))
+      .filter((i) => i.url && i.title);
+    return NextResponse.json({ listings });
   } catch (err) {
     return NextResponse.json({ error: "Failed" }, { status: 500 });
   }

--- a/src/components/ExternalLinkIcon.tsx
+++ b/src/components/ExternalLinkIcon.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+
+export function ExternalLinkIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  )
+}

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -40,20 +40,25 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
           <h2 className="text-2xl font-bold">{product.title}</h2>
           <p className="text-sm">{product.description}</p>
           {ebayLinks.length > 0 && (
-            <ul className="space-y-1 pt-2">
-              {ebayLinks.map((link, idx) => (
-                <li key={idx}>
-                  <a
-                    href={link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline text-blue-400"
-                  >
-                    eBay Link
-                  </a>
-                </li>
-              ))}
-            </ul>
+            <div className="pt-4 space-y-1">
+              <h4 className="text-sm font-medium text-muted-foreground">
+                Purchase on eBay
+              </h4>
+              <ul className="space-y-1">
+                {ebayLinks.map((listing, idx) => (
+                  <li key={idx}>
+                    <a
+                      href={listing.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline text-blue-400"
+                    >
+                      {listing.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import clsx from "clsx";
-import { ExternalLink } from "lucide-react";
+import { ExternalLinkIcon } from "./ExternalLinkIcon";
 import { createPortal } from "react-dom";
 import { useState } from "react";
 import { useEbayListings } from "@/hooks/use-ebay-listings";
@@ -88,13 +88,13 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
                       href={listing.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-baseline gap-1 text-white no-underline transition-opacity hover:opacity-70 focus-visible:opacity-70"
+                      className="inline-flex items-center gap-1 text-white no-underline transition-opacity hover:opacity-70 focus-visible:opacity-70"
                       onMouseEnter={showPreview(listing.image)}
                       onMouseLeave={hidePreview}
                       onFocus={showPreview(listing.image)}
                       onBlur={hidePreview}
                     >
-                      <ExternalLink className="mr-1 inline size-4" aria-hidden="true" />
+                      <ExternalLinkIcon className="h-4 w-4 shrink-0" />
                       {listing.title}
                     </a>
                   </li>

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import clsx from "clsx";
+import { ExternalLink } from "lucide-react";
 import { useEbayListings } from "@/hooks/use-ebay-listings";
 
 interface Product {
@@ -46,15 +47,26 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
               </h4>
               <ul className="space-y-1">
                 {ebayLinks.map((listing, idx) => (
-                  <li key={idx}>
+                  <li key={idx} className="relative group">
                     <a
                       href={listing.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="underline text-blue-400"
+                      className="flex items-center gap-1 text-white no-underline transition-opacity hover:opacity-70 focus-visible:opacity-70"
                     >
                       {listing.title}
+                      <ExternalLink className="size-4" aria-hidden="true" />
                     </a>
+                    {listing.image && (
+                      <Image
+                        src={listing.image}
+                        alt=""
+                        width={160}
+                        height={160}
+                        unoptimized
+                        className="pointer-events-none absolute left-0 top-full z-10 mt-2 hidden rounded-md border bg-background object-cover shadow-lg group-hover:block group-focus-visible:block"
+                      />
+                    )}
                   </li>
                 ))}
               </ul>

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import clsx from "clsx";
 import { ExternalLinkIcon } from "./ExternalLinkIcon";
+import { Spinner } from "./Spinner";
 import { createPortal } from "react-dom";
 import { useState } from "react";
 import { useEbayListings } from "@/hooks/use-ebay-listings";
@@ -18,7 +19,7 @@ interface ProductModalProps {
 }
 
 export function ProductModal({ product, onClose }: ProductModalProps) {
-  const ebayLinks = useEbayListings(product.title);
+  const { listings: ebayLinks, loading } = useEbayListings(product.title);
   const [preview, setPreview] = useState<{
     src: string;
     x: number;
@@ -76,32 +77,38 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
           <h3 className="text-lg font-semibold">{product.year}</h3>
           <h2 className="text-2xl font-bold">{product.title}</h2>
           <p className="text-sm">{product.description}</p>
-          {ebayLinks.length > 0 && (
-            <div className="pt-4 space-y-1">
-              <h4 className="text-sm font-medium text-muted-foreground">
-                Purchase on eBay
-              </h4>
-              <ul className="space-y-1">
-                {ebayLinks.map((listing, idx) => (
-                  <li key={idx}>
-                    <a
-                      href={listing.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-white no-underline transition-opacity hover:opacity-70 focus-visible:opacity-70"
-                      onMouseEnter={showPreview(listing.image)}
-                      onMouseLeave={hidePreview}
-                      onFocus={showPreview(listing.image)}
-                      onBlur={hidePreview}
-                    >
-                      <ExternalLinkIcon className="h-4 w-4 shrink-0" />
-                      {listing.title}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          <div className="pt-4 space-y-1">
+            {loading && (
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                <Spinner className="h-4 w-4" />
+                Searching eBay...
+              </div>
+            )}
+            {!loading && ebayLinks.length > 0 && (
+              <>
+                <h4 className="text-sm font-medium text-muted-foreground">Purchase on eBay</h4>
+                <ul className="space-y-1">
+                  {ebayLinks.map((listing, idx) => (
+                    <li key={idx} className="animate-in fade-in slide-in-from-bottom-1" style={{ animationDelay: `${idx * 50}ms` }}>
+                      <a
+                        href={listing.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-white no-underline transition-opacity hover:opacity-70 focus-visible:opacity-70"
+                        onMouseEnter={showPreview(listing.image)}
+                        onMouseLeave={hidePreview}
+                        onFocus={showPreview(listing.image)}
+                        onBlur={hidePreview}
+                      >
+                        <ExternalLinkIcon className="h-4 w-4 shrink-0" />
+                        {listing.title}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </div>
         </div>
       </div>
       {preview &&

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,12 @@
+import clsx from "clsx"
+
+export function Spinner({ className }: { className?: string }) {
+  return (
+    <div
+      className={clsx(
+        "h-4 w-4 animate-spin rounded-full border-2 border-current border-r-transparent",
+        className
+      )}
+    />
+  )
+}

--- a/src/hooks/use-ebay-listings.ts
+++ b/src/hooks/use-ebay-listings.ts
@@ -15,11 +15,9 @@ export function useEbayListings(query: string | null) {
     if (!query) return;
     let cancelled = false;
     const fetchListings = async () => {
-      console.log("Fetching eBay listings...");
       try {
         const res = await fetch(`/api/ebay?q=${encodeURIComponent(query)}`);
         const data = await res.json();
-        console.log("eBay response:", data);
         if (!res.ok) return;
         if (!cancelled) {
           setLinks(Array.isArray(data.listings) ? data.listings : []);

--- a/src/hooks/use-ebay-listings.ts
+++ b/src/hooks/use-ebay-listings.ts
@@ -10,12 +10,14 @@ export interface EbayListing {
 
 export function useEbayListings(query: string | null) {
   const [links, setLinks] = useState<EbayListing[]>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!query) return;
     let cancelled = false;
     const fetchListings = async () => {
       try {
+        setLoading(true);
         const res = await fetch(`/api/ebay?q=${encodeURIComponent(query)}`);
         const data = await res.json();
         if (!res.ok) return;
@@ -24,6 +26,8 @@ export function useEbayListings(query: string | null) {
         }
       } catch (err) {
         console.error("eBay listings error:", err);
+      } finally {
+        if (!cancelled) setLoading(false);
       }
     };
     fetchListings();
@@ -32,5 +36,5 @@ export function useEbayListings(query: string | null) {
     };
   }, [query]);
 
-  return links;
+  return { listings: links, loading };
 }

--- a/src/hooks/use-ebay-listings.ts
+++ b/src/hooks/use-ebay-listings.ts
@@ -2,8 +2,13 @@
 
 import { useEffect, useState } from "react";
 
+export interface EbayListing {
+  url: string;
+  title: string;
+}
+
 export function useEbayListings(query: string | null) {
-  const [links, setLinks] = useState<string[]>([]);
+  const [links, setLinks] = useState<EbayListing[]>([]);
 
   useEffect(() => {
     if (!query) return;
@@ -16,7 +21,7 @@ export function useEbayListings(query: string | null) {
         console.log("eBay response:", data);
         if (!res.ok) return;
         if (!cancelled) {
-          setLinks(Array.isArray(data.links) ? data.links : []);
+          setLinks(Array.isArray(data.listings) ? data.listings : []);
         }
       } catch (err) {
         console.error("eBay listings error:", err);

--- a/src/hooks/use-ebay-listings.ts
+++ b/src/hooks/use-ebay-listings.ts
@@ -3,8 +3,9 @@
 import { useEffect, useState } from "react";
 
 export interface EbayListing {
-  url: string;
-  title: string;
+  url: string
+  title: string
+  image?: string | null
 }
 
 export function useEbayListings(query: string | null) {


### PR DESCRIPTION
## Summary
- include eBay listing titles and URLs in the API
- expose listing data in `useEbayListings`
- display eBay listings with titles and a single header in product modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68756fe02c30832eaae448adf58d5ae4