### PR TITLE
Add eBay affiliate campaign tracking to item links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ EBAY_SANDBOX_OAUTH_TOKEN=your-sandbox-oauth-token
 
 # OAuth token for the production environment (required when EBAY_ENV=production)
 EBAY_OAUTH_TOKEN=your-production-oauth-token
+
+# eBay Partner Network campaign ID for affiliate tracking
+EBAY_CAMPAIGN_ID=5339118344

--- a/README.md
+++ b/README.md
@@ -20,5 +20,12 @@ sandbox or production environment.
    - When using the sandbox, provide `EBAY_SANDBOX_OAUTH_TOKEN`.
    - When using production, provide `EBAY_OAUTH_TOKEN`.
 
+3. Set `EBAY_CAMPAIGN_ID` to your eBay Partner Network campaign ID so links
+   include your affiliate tracking. Example:
+
+   ```bash
+   EBAY_CAMPAIGN_ID=5339118344
+   ```
+
 Alternatively, export the variables in your shell before starting the
 development server.

--- a/src/app/api/ebay/route.ts
+++ b/src/app/api/ebay/route.ts
@@ -5,6 +5,13 @@ const ENDPOINTS = {
   production: "https://api.ebay.com/buy/browse/v1/item_summary/search",
 } as const;
 
+const CAMP_ID = process.env.EBAY_CAMPAIGN_ID || "5339118344";
+
+function appendCampId(url: string) {
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}campid=${CAMP_ID}`;
+}
+
 function getConfig(env?: string) {
   const mode = env === "production" ? "production" : "sandbox";
   const token =
@@ -75,14 +82,14 @@ export async function GET(request: NextRequest) {
     const items = data.itemSummaries || [];
     const listings = items
       .map((item: any) => ({
-        url: item.itemWebUrl,
+        url: item.itemWebUrl ? appendCampId(item.itemWebUrl) : null,
         title: item.title,
         image:
           item.image?.imageUrl ||
           item.thumbnailImages?.[0]?.imageUrl ||
           null,
       }))
-      .filter((i: { url: any; title: any; }) => i.url && i.title);
+      .filter((i: { url: string | null; title: any }) => i.url && i.title);
     return NextResponse.json({ listings });
   } catch (err: any) {
     const errorInfo = { ...requestInfo, message: err?.message ?? String(err) };


### PR DESCRIPTION
## Summary
- append `campid` query parameter to eBay item URLs for Partner Network tracking
- document `EBAY_CAMPAIGN_ID` in README and `.env.example`

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688f9f05c0c0832e98ef2a03724d8e0f