### PR TITLE
Switch to client-credentials OAuth for eBay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,12 @@ EBAY_ENV=sandbox
 # OAuth token obtained via the sandbox using client credentials
 EBAY_SANDBOX_OAUTH_TOKEN=your-sandbox-oauth-token
 
-# OAuth token for the production environment (optional when using refresh token)
+# OAuth token for the production environment (optional fallback)
 EBAY_OAUTH_TOKEN=your-production-oauth-token
 
-# Optional: provide these to enable automatic refresh of the production token
+# Optional: provide these to enable automatic fetching of the production token
 EBAY_PROD_CLIENT_ID=your-client-id
 EBAY_PROD_CLIENT_SECRET=your-client-secret
-EBAY_PROD_REFRESH_TOKEN=your-refresh-token
 
 # eBay Partner Network campaign ID for affiliate tracking
 EBAY_CAMPAIGN_ID=5339118344

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ sandbox or production environment.
 2. Set `EBAY_ENV` to either `sandbox` or `production`.
    - When using the sandbox, provide `EBAY_SANDBOX_OAUTH_TOKEN`.
    - For production you can either set `EBAY_OAUTH_TOKEN` manually or supply
-     `EBAY_PROD_CLIENT_ID`, `EBAY_PROD_CLIENT_SECRET` and
-     `EBAY_PROD_REFRESH_TOKEN` to enable automatic token refresh.
+     `EBAY_PROD_CLIENT_ID` and `EBAY_PROD_CLIENT_SECRET` to enable automatic
+     token retrieval via the client‑credentials grant.
 
 3. Set `EBAY_CAMPAIGN_ID` to your eBay Partner Network campaign ID so links
    include your affiliate tracking. Example:

--- a/src/app/api/ebay/route.ts
+++ b/src/app/api/ebay/route.ts
@@ -13,8 +13,11 @@ function appendCampId(url: string) {
   return `${url}${separator}campid=${CAMP_ID}`;
 }
 
-function getConfig(env?: string) {
-  const mode = env === "production" ? "production" : "sandbox";
+function getConfig(env?: string): {
+  mode: "sandbox" | "production";
+  endpoint: string;
+} {
+  const mode: "sandbox" | "production" = env === "production" ? "production" : "sandbox";
   return { mode, endpoint: ENDPOINTS[mode] };
 }
 

--- a/src/lib/ebayAuth.ts
+++ b/src/lib/ebayAuth.ts
@@ -1,11 +1,11 @@
-let prodToken: string | null = null;
+let prodToken: string | undefined;
 let prodExpiry = 0;
 
 /**
  * Returns an OAuth access token for the specified environment. Sandbox tokens
  * are read directly from the environment variable. Production tokens are
- * automatically refreshed using the refresh token flow if client credentials
- * are provided.
+ * obtained using the client‑credentials grant and cached in memory until they
+ * expire.
  */
 export async function getAccessToken(env: 'sandbox' | 'production'): Promise<string | undefined> {
   if (env === 'sandbox') {
@@ -19,16 +19,14 @@ export async function getAccessToken(env: 'sandbox' | 'production'): Promise<str
 
   const clientId = process.env.EBAY_PROD_CLIENT_ID;
   const clientSecret = process.env.EBAY_PROD_CLIENT_SECRET;
-  const refreshToken = process.env.EBAY_PROD_REFRESH_TOKEN;
 
-  if (!clientId || !clientSecret || !refreshToken) {
+  if (!clientId || !clientSecret) {
     return process.env.EBAY_OAUTH_TOKEN;
   }
 
   const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
   const params = new URLSearchParams();
-  params.append('grant_type', 'refresh_token');
-  params.append('refresh_token', refreshToken);
+  params.append('grant_type', 'client_credentials');
   // Using the basic browse scope
   params.append('scope', 'https://api.ebay.com/oauth/api_scope');
 
@@ -43,7 +41,7 @@ export async function getAccessToken(env: 'sandbox' | 'production'): Promise<str
 
   if (!res.ok) {
     const text = await res.text();
-    console.error('Failed to refresh eBay token', { status: res.status, text });
+    console.error('Failed to fetch eBay token', { status: res.status, text });
     return process.env.EBAY_OAUTH_TOKEN;
   }
 


### PR DESCRIPTION
## Summary
- Fetch eBay production tokens via client-credentials grant and cache until expiry
- Document new client-credentials setup and remove refresh token references
- Tighten API route typing for environment selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688fa6d03ee4832eb4f1b1c9ebdda480