### PR TITLE
feat: add featured products grid

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,13 +39,13 @@ export default function Home() {
           Made by Apple
         </h1>
         <section className="mb-16">
-          <h2 className="text-2xl font-semibold text-center mb-8">Featured Products</h2>
+          <h2 className="text-2xl font-semibold text-center mb-4">Featured Vintage Products</h2>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-8">
             {featuredProducts.map((product, index) => (
               <div
                 key={index}
                 onClick={() => setOpenProduct(product)}
-                className="cursor-pointer text-center transition-colors hover:bg-accent p-4 rounded-md"
+                className="cursor-pointer text-center transition-colors hover:bg-accent p-2"
               >
                 {product.image && (
                   <Image
@@ -63,6 +63,7 @@ export default function Home() {
             ))}
           </div>
         </section>
+        <h2 className="text-2xl font-semibold text-center mb-4">All Products</h2>
         <div className="border-t border-border">
           {products.map((product, index) => {
             const showYearHeader = index === 0 || product.year !== products[index - 1].year;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,12 +21,48 @@ interface Product {
 }
 export default function Home() {
   const [openProduct, setOpenProduct] = useState<Product | null>(null);
+  const featuredProductTitles = [
+    "Twentieth Anniversary Macintosh",
+    "iMac G3",
+    "iPhone (1st generation)",
+    "iPod Mini (1st gen)",
+    "Power Mac G5",
+    "Power Mac G4 Cube",
+  ];
+  const featuredProducts = featuredProductTitles
+    .map((title) => products.find((p) => p.title === title))
+    .filter(Boolean) as Product[];
   return (
     <main className="min-h-screen bg-background font-body text-foreground">
       <div className="container mx-auto max-w-4xl py-16 px-4 sm:py-24 sm:px-6 lg:px-8">
         <h1 className="text-4xl md:text-8xl font-bold text-center mb-16 font-headline tracking-tight">
           Made by Apple
         </h1>
+        <section className="mb-16">
+          <h2 className="text-2xl font-semibold text-center mb-8">Featured Products</h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-8">
+            {featuredProducts.map((product, index) => (
+              <div
+                key={index}
+                onClick={() => setOpenProduct(product)}
+                className="cursor-pointer text-center transition-colors hover:bg-accent p-4 rounded-md"
+              >
+                {product.image && (
+                  <Image
+                    src={product.image}
+                    alt={product.title}
+                    width={160}
+                    height={160}
+                    unoptimized
+                    className="mx-auto h-32 w-32 object-contain"
+                  />
+                )}
+                <h3 className="mt-4 font-semibold">{product.title}</h3>
+                <p className="text-sm text-muted-foreground">{product.year}</p>
+              </div>
+            ))}
+          </div>
+        </section>
         <div className="border-t border-border">
           {products.map((product, index) => {
             const showYearHeader = index === 0 || product.year !== products[index - 1].year;


### PR DESCRIPTION
## Summary
- highlight six notable items with a Featured Products grid under the main heading
- each featured product displays its image, name, and release year and opens the product modal on click

## Testing
- `npm run lint` (fails: prompts for ESLint config)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68901726d314832e915dc469737606f5