### PR TITLE
Add close button to ProductModal

### DIFF
--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -62,6 +62,16 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
       <div
         className="relative mx-auto flex max-h-full w-full max-w-5xl flex-col items-center gap-8 md:flex-row"
       >
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          className="absolute top-4 right-4 flex h-[50px] w-[50px] items-center justify-center rounded-full bg-gray-500 text-white"
+          aria-label="Close"
+        >
+          X
+        </button>
         {product.image && (
           <div className="relative h-96 w-full md:h-[80vh] md:w-1/2">
             <Image


### PR DESCRIPTION
## Summary
- Add a 50x50 gray circular X button to the top-right of `ProductModal` that calls `onClose`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68901f3b50ec832ea03dbfd83f4e072c