### PR TITLE
feat: add draggable product modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "genkit": "^1.13.0",
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
+    "framer-motion": "^11.0.0",
     "patch-package": "^8.0.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import clsx from "clsx";
 import { ExternalLinkIcon } from "./ExternalLinkIcon";
@@ -5,6 +7,19 @@ import { Spinner } from "./Spinner";
 import { createPortal } from "react-dom";
 import { useState } from "react";
 import { useEbayListings } from "@/hooks/use-ebay-listings";
+import React from "react";
+import {
+  motion,
+  PanInfo,
+  useMotionTemplate,
+  useSpring,
+  useTransform,
+} from "framer-motion";
+
+export const MARGIN = 16;
+export const MAX_BLUR = 12;
+export const MAX_OPACITY = 0.2;
+export const DISMISS_DISTANCE = 50;
 
 interface Product {
   year: string;
@@ -19,23 +34,30 @@ interface ProductModalProps {
 }
 
 export function ProductModal({ product, onClose }: ProductModalProps) {
-  const { listings: ebayLinks, loading, error } = useEbayListings(product.title);
+  const { listings: ebayLinks, loading, error } = useEbayListings(
+    product.title,
+  );
   const [preview, setPreview] = useState<{
     src: string;
     x: number;
     y: number;
   } | null>(null);
 
+  const [height, setHeight] = useState(0);
+  const y = useSpring(0, { damping: 50, stiffness: 550 });
+
+  const blur = useTransform(y, [0, height], [MAX_BLUR, 0]);
+  const opacity = useTransform(y, [0, height], [MAX_OPACITY, 0]);
+
   const canHover = () =>
     typeof window !== "undefined" &&
     window.matchMedia("(hover: hover)").matches;
 
-  const showPreview = (
-    src: string | null | undefined,
-  ) =>
+  const showPreview = (src: string | null | undefined) =>
     (
-      e: React.MouseEvent<HTMLAnchorElement> |
-        React.FocusEvent<HTMLAnchorElement>
+      e:
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.FocusEvent<HTMLAnchorElement>,
     ) => {
       if (!src) return;
       if (e.type !== "focus" && !canHover()) return;
@@ -54,74 +76,156 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
     };
 
   const hidePreview = () => setPreview(null);
+
+  function handleClose() {
+    y.set(height + MARGIN);
+    setTimeout(onClose, 300);
+  }
+
+  function onPanStart() {
+    grab.start();
+  }
+
+  function onPanEnd(_: PointerEvent, { velocity }: PanInfo) {
+    grab.end();
+    if (y.get() < 0) {
+      y.set(0);
+      return;
+    }
+    const projectedY = y.get() + project(velocity.y);
+    if (projectedY >= DISMISS_DISTANCE) {
+      handleClose();
+    } else {
+      y.set(0);
+    }
+  }
+
+  function onPan(_: PointerEvent, { offset }: PanInfo) {
+    let newY = offset.y;
+    newY = dampen(newY, [0, height]);
+    // use jump to update spring immediately without animation
+    // @ts-ignore - jump is available on motion values
+    y.jump(newY);
+  }
+
+  const sheetRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node) {
+        const bounds = node.getBoundingClientRect();
+        setHeight(bounds.height);
+        // start off-screen then animate in
+        y.set(bounds.height + MARGIN);
+        requestAnimationFrame(() => y.set(0));
+      }
+    },
+    [y],
+  );
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-white/100 p-4"
-    >
-      <div
-        className="relative mx-auto flex max-h-full w-full max-w-5xl flex-col items-center gap-8 md:flex-row"
+    <div className="fixed inset-0 z-50">
+      {/* Backdrop with blur and opacity */}
+      <motion.div
+        className="absolute inset-0 bg-black"
+        style={{
+          opacity,
+          backdropFilter: useMotionTemplate`blur(${blur}px)`,
+        }}
+        onClick={handleClose}
+      />
+
+      {/* Sheet */}
+      <motion.div
+        ref={sheetRef}
+        onPanStart={onPanStart}
+        onPanEnd={onPanEnd}
+        onPan={onPan}
+        className="absolute left-2 right-2 bottom-2 bg-white dark:bg-gray1 rounded-[32px] max-h-[calc(100%-32px)] overflow-y-auto p-4 cursor-grab active:cursor-grabbing max-sm:rounded-16"
+        style={{ y, "--margin": `${MARGIN}px` } as React.CSSProperties}
       >
-        {product.image && (
-          <div className="relative h-96 w-full md:h-[80vh] md:w-1/2">
-            <Image
-              src={product.image}
-              alt={product.title}
-              fill
-              unoptimized
-              className="object-contain animate-in zoom-in-95 fade-in"
-            />
-          </div>
-        )}
-        <div className={clsx("text-black space-y-2 overflow-y-auto", product.image ? "md:w-1/2" : "w-full")}>
-        <p className="text-black cursor-pointer font-semibold transition-opacity hover:opacity-50 focus-visible:opacity-50 py-4" onClick={onClose}>&larr; Back to all products</p>
-          <h3 className="text-lg font-semibold">{product.year}</h3>
-          <h2 className="text-2xl font-bold">{product.title}</h2>
-          <p className="text-sm">{product.description}</p>
-          <div className="pt-4 space-y-1">
-            {loading && (
-              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-                <Spinner className="h-4 w-4" />
-                Searching eBay...
-              </div>
+        <motion.div className="w-10 h-1 bg-gray7 rounded-full mx-auto mb-4" />
+        <div className="relative mx-auto flex max-h-full w-full max-w-5xl flex-col items-center gap-8 md:flex-row">
+          {product.image && (
+            <div className="relative h-96 w-full md:h-[80vh] md:w-1/2">
+              <Image
+                src={product.image}
+                alt={product.title}
+                fill
+                unoptimized
+                className="object-contain animate-in zoom-in-95 fade-in"
+              />
+            </div>
+          )}
+          <div
+            className={clsx(
+              "text-black space-y-2", // removed overflow-y-auto since sheet has it
+              product.image ? "md:w-1/2" : "w-full",
             )}
-            {!loading && ebayLinks.length > 0 && !error && (
-              <>
-                <h4 className="text-sm font-medium text-muted-foreground">Purchase on eBay</h4>
-                <ul className="space-y-2">
-                  {ebayLinks.map((listing, idx) => (
-                    <li
-                      key={idx}
-                      className="animate-in duration-700 fade-in slide-in-from-bottom-1"
-                      style={{ animationDelay: `${idx * 50}ms` }}
-                    >
-                      <a
-                        href={listing.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-4 text-black no-underline transition-opacity hover:opacity-50 focus-visible:opacity-50"
-                        onMouseEnter={showPreview(listing.image)}
-                        onMouseLeave={hidePreview}
-                        onFocus={showPreview(listing.image)}
-                        onBlur={hidePreview}
-                      >
-                        <ExternalLinkIcon className="h-4 w-4 shrink-0" />
-                        {listing.title}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-                <div className="text-muted-foreground py-4 text-sm">
-                  <h5 className="font-semibold">This site uses affiliate links.</h5>
-                    Products on this website use eBay affiliate links. If you purchase an item through one of these links, I receive a small payment around 2-4%. It's how I pay some of the monthly hosting costs associated with this site.
+          >
+            <p
+              className="text-black cursor-pointer font-semibold transition-opacity hover:opacity-50 focus-visible:opacity-50 py-4"
+              onClick={handleClose}
+            >
+              &larr; Back to all products
+            </p>
+            <h3 className="text-lg font-semibold">{product.year}</h3>
+            <h2 className="text-2xl font-bold">{product.title}</h2>
+            <p className="text-sm">{product.description}</p>
+            <div className="pt-4 space-y-1">
+              {loading && (
+                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+                  <Spinner className="h-4 w-4" />
+                  Searching eBay...
                 </div>
-              </>
-            )}
-            {!loading && (ebayLinks.length === 0 || error) && (
-              <h4 className="text-sm font-medium text-muted-foreground">No matching items on eBay right now.</h4>
-            )}
+              )}
+              {!loading && ebayLinks.length > 0 && !error && (
+                <>
+                  <h4 className="text-sm font-medium text-muted-foreground">
+                    Purchase on eBay
+                  </h4>
+                  <ul className="space-y-2">
+                    {ebayLinks.map((listing, idx) => (
+                      <li
+                        key={idx}
+                        className="animate-in duration-700 fade-in slide-in-from-bottom-1"
+                        style={{ animationDelay: `${idx * 50}ms` }}
+                      >
+                        <a
+                          href={listing.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-4 text-black no-underline transition-opacity hover:opacity-50 focus-visible:opacity-50"
+                          onMouseEnter={showPreview(listing.image)}
+                          onMouseLeave={hidePreview}
+                          onFocus={showPreview(listing.image)}
+                          onBlur={hidePreview}
+                        >
+                          <ExternalLinkIcon className="h-4 w-4 shrink-0" />
+                          {listing.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="text-muted-foreground py-4 text-sm">
+                    <h5 className="font-semibold">
+                      This site uses affiliate links.
+                    </h5>
+                    Products on this website use eBay affiliate links. If you
+                    purchase an item through one of these links, I receive a
+                    small payment around 2-4%. It's how I pay some of the monthly
+                    hosting costs associated with this site.
+                  </div>
+                </>
+              )}
+              {!loading && (ebayLinks.length === 0 || error) && (
+                <h4 className="text-sm font-medium text-muted-foreground">
+                  No matching items on eBay right now.
+                </h4>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </motion.div>
+
       {preview &&
         createPortal(
           <Image
@@ -138,3 +242,30 @@ export function ProductModal({ product, onClose }: ProductModalProps) {
     </div>
   );
 }
+
+export function project(initialVelocity: number, decelerationRate = 0.998) {
+  return (
+    ((initialVelocity / 1000) * decelerationRate) /
+    (1 - decelerationRate)
+  );
+}
+
+function dampen(val: number, [min, max]: [number, number], factor = 2) {
+  if (val > max) {
+    const extra = val - max;
+    const dampenedExtra = extra > 0 ? Math.sqrt(extra) : -Math.sqrt(-extra);
+    return max + dampenedExtra * factor;
+  } else if (val < min) {
+    const extra = val - min;
+    const dampenedExtra = extra > 0 ? Math.sqrt(extra) : -Math.sqrt(-extra);
+    return min + dampenedExtra * factor;
+  } else {
+    return val;
+  }
+}
+
+export const grab = {
+  start: () => document.body.classList.add("gesture-grabbing"),
+  end: () => document.body.classList.remove("gesture-grabbing"),
+};
+


### PR DESCRIPTION
## Summary
- refactor ProductModal into a draggable bottom sheet with animated backdrop blur
- add framer-motion for spring and transform utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689278ab9bfc832e9d01e1c90201dc38